### PR TITLE
로딩 컴포넌트를 개선한 로직입니다.

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -36,6 +36,7 @@ export default function Header({ isMobile = false }: HeaderProps) {
 						<Link href="/">
 							<Logo src="/svgs/logo.svg" alt="Logo" />
 						</Link>
+						{/* login -> Login */}
 						<Link href="/Login">
 							<LoginButton>로그인</LoginButton>
 						</Link>
@@ -48,6 +49,7 @@ export default function Header({ isMobile = false }: HeaderProps) {
 					</Link>
 					<Btns>
 						<Button style="menu" />
+						{/* login -> MobileLogin */}
 						<Link href="/MobileLogin">
 							<Button style="login" />
 						</Link>

--- a/src/hooks/useLoading.ts
+++ b/src/hooks/useLoading.ts
@@ -1,24 +1,29 @@
-// 경로가 변경될 때마다 로딩 상태 업데이트 
-'use client';
-import { useEffect } from 'react';
-import { usePathname } from 'next/navigation';
-import { useLoadingStore } from '@/stores/loadingStore';
+// 경로가 변경될 때마다 로딩 상태 업데이트
+"use client";
+import { useEffect } from "react";
+import { usePathname } from "next/navigation";
+import { useLoadingStore } from "@/stores/loadingStore";
 
 export const useLoading = () => {
-  const { isLoading, setIsLoading } = useLoadingStore();
-  const pathname = usePathname();
+	const { isLoading, setIsLoading } = useLoadingStore();
+	const pathname = usePathname();
 
-  useEffect(() => {
-    // 경로 변경 시작 시 로딩 상태를 true로 설정
-    setIsLoading(true);
+	useEffect(() => {
+		setIsLoading(true);
+		// 완료시 실행할 콜백 함수
+		const onPageLoad = () => {
+			setIsLoading(false);
+		};
 
-    // 페이지 로드 완료 시 로딩 상태를 false로 설정
-    const timeout = setTimeout(() => {
-      setIsLoading(false);
-    }, 1000); // 나중에 수정 필요함 
+		// document 로딩상태 감지
+		if (document.readyState === "complete") {
+			onPageLoad();
+		} else {
+			window.addEventListener("load", onPageLoad, false);
+			// 이벤트 클린업
+			return () => window.removeEventListener("load", onPageLoad);
+		}
+	}, [pathname, setIsLoading]);
 
-    return () => clearTimeout(timeout);
-  }, [pathname, setIsLoading]);
-
-  return isLoading;
+	return isLoading;
 };


### PR DESCRIPTION
기존의 코드에서 setTimeout함수로 1초뒤에 없어지게 만들었던 코드를 이전의 코드리뷰에서 올려드린 방법으로 개선하여 페이지가 load가 완료되면 없어지도록 개선하였습니다.

<details>
  <summary>변경된 코드</summary>

![스크린샷 2024-11-14 202512](https://github.com/user-attachments/assets/0a540850-1e87-4775-935a-93a58afd1cbe)

문서와 하위 이미지들까지 모두 불러온 뒤에 로딩화면이 사라지도록 readyState의 값으로 complete를 주어 완전히 load되면 로딩화면이 없어지도록 변경하였고 로딩이 되지 않았다면 else가 실행되어 load될때 까지 기다리도록 코드를 작성했습니다.

</details>