### PR TITLE
메인페이지 구인글 리스트 api 연동 및 코드 추상화 진행

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
 				"@types/react-responsive": "^8.0.8",
 				"cookie": "^1.0.1",
 				"cookies-next": "^4.2.1",
+				"dayjs": "^1.11.13",
 				"nanoid": "^5.0.7",
 				"next": "14.2.4",
 				"next-auth": "^4.24.7",
@@ -5219,6 +5220,12 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
+		},
+		"node_modules/dayjs": {
+			"version": "1.11.13",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
+			"integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
+			"license": "MIT"
 		},
 		"node_modules/debounce": {
 			"version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"@types/react-responsive": "^8.0.8",
 		"cookie": "^1.0.1",
 		"cookies-next": "^4.2.1",
+		"dayjs": "^1.11.13",
 		"nanoid": "^5.0.7",
 		"next": "14.2.4",
 		"next-auth": "^4.24.7",

--- a/src/data/MainOptions/mainOptions.ts
+++ b/src/data/MainOptions/mainOptions.ts
@@ -1,0 +1,28 @@
+export const questOptions = [
+	{ value: "일반비경" },
+	{ value: "이벤트 퀘스트" },
+	{ value: "영역 토벌" },
+	{ value: "일일 임무" },
+	{ value: "맵 탐사" },
+	{ value: "채집" },
+];
+
+export const lvOptions = [
+	{ value: "1" },
+	{ value: "2" },
+	{ value: "3" },
+	{ value: "4" },
+	{ value: "5" },
+	{ value: "6" },
+	{ value: "7" },
+	{ value: "8" },
+	{ value: "9" },
+];
+
+export const regionOptions = [
+	{ value: "ASIA" },
+	{ value: "AMERICA" },
+	{ value: "EUROPE" },
+	{ value: "CHINA" },
+	{ value: "TW, HK, MO" },
+];

--- a/src/features/matching/components/MatchingHeader/index.tsx
+++ b/src/features/matching/components/MatchingHeader/index.tsx
@@ -1,0 +1,57 @@
+import {
+	MatchingHeaderContainer,
+	UserName,
+	QuestType,
+	WorldLevel,
+	Message,
+	TimeAgo,
+	MoreOptions,
+	Gap,
+} from "./style";
+
+type MatchingHeaderProps = {
+	selectType: string;
+	handleSelectType: (type: string) => void;
+};
+
+export default function MatchingHeader({
+	selectType,
+	handleSelectType,
+}: MatchingHeaderProps) {
+	return (
+		<MatchingHeaderContainer>
+			<UserName
+				select={selectType === "userName"}
+				onClick={() => handleSelectType("userName")}
+			>
+				유저명
+			</UserName>
+			<QuestType
+				select={selectType === "questType"}
+				onClick={() => handleSelectType("questType")}
+			>
+				퀘스트 종류
+			</QuestType>
+			<WorldLevel
+				select={selectType === "worldLevel"}
+				onClick={() => handleSelectType("worldLevel")}
+			>
+				월드 레벨
+			</WorldLevel>
+			<Message
+				select={selectType === "message"}
+				onClick={() => handleSelectType("message")}
+			>
+				이야기
+			</Message>
+			<TimeAgo
+				select={selectType === "timeAgo"}
+				onClick={() => handleSelectType("timeAgo")}
+			>
+				등록일시
+			</TimeAgo>
+			<MoreOptions></MoreOptions>
+			<Gap />
+		</MatchingHeaderContainer>
+	);
+}

--- a/src/features/matching/components/MatchingHeader/style.ts
+++ b/src/features/matching/components/MatchingHeader/style.ts
@@ -1,0 +1,167 @@
+import { styled } from "@/../styled-system/jsx";
+
+const flexCenter = {
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	height: "100%",
+};
+
+const fontStyle = {
+	color: "gray.01",
+	fontSize: "14px",
+	fontWeight: "bold",
+};
+
+const flexItem = {
+	...flexCenter,
+	...fontStyle,
+	position: "relative",
+	cursor: "pointer",
+	flex: "1 1 auto",
+};
+
+export const MatchingHeaderContainer = styled("div", {
+	base: {
+		display: "flex",
+		alignItems: "center",
+		maxWidth: "1124px",
+		minWidth: "883px",
+		width: "100%",
+		height: "32px",
+		marginLeft: "5px",
+		backgroundColor: "gray.06",
+		flexShrink: 0,
+	},
+});
+
+export const UserName = styled("div", {
+	base: {
+		...flexItem,
+		flex: "1 1 200px",
+	},
+	variants: {
+		select: {
+			true: {
+				color: "secondary.01",
+				"&::before": {
+					content: '""',
+					position: "absolute",
+					bottom: 0,
+					left: "50%",
+					transform: "translateX(-50%)",
+					width: "53px", // 37 + 16
+					height: "2px",
+					backgroundColor: "secondary.01",
+				},
+			},
+		},
+	},
+});
+
+export const QuestType = styled(UserName, {
+	base: {},
+	variants: {
+		select: {
+			true: {
+				color: "secondary.01",
+				"&::before": {
+					content: '""',
+					position: "absolute",
+					bottom: 0,
+					left: "50%",
+					transform: "translateX(-50%)",
+					width: "80px", // 64 + 16
+					height: "2px",
+					backgroundColor: "secondary.01",
+				},
+			},
+		},
+	},
+});
+
+export const WorldLevel = styled("div", {
+	base: {
+		...flexItem,
+		flex: "1 1 100px",
+	},
+	variants: {
+		select: {
+			true: {
+				color: "secondary.01",
+				"&::before": {
+					content: '""',
+					position: "absolute",
+					bottom: 0,
+					left: "50%",
+					transform: "translateX(-50%)",
+					width: "68px", // 52 + 16
+					height: "2px",
+					backgroundColor: "secondary.01",
+				},
+			},
+		},
+	},
+});
+
+export const Message = styled("div", {
+	base: {
+		...flexItem,
+		flex: "1 1 386px",
+	},
+	variants: {
+		select: {
+			true: {
+				color: "secondary.01",
+				"&::before": {
+					content: '""',
+					position: "absolute",
+					bottom: 0,
+					left: "50%",
+					transform: "translateX(-50%)",
+					width: "53px", // 37 + 16
+					height: "2px",
+					backgroundColor: "secondary.01",
+				},
+			},
+		},
+	},
+});
+
+export const TimeAgo = styled("div", {
+	base: {
+		...flexItem,
+		flex: "1 1 140px",
+	},
+	variants: {
+		select: {
+			true: {
+				color: "secondary.01",
+				"&::before": {
+					content: '""',
+					position: "absolute",
+					bottom: 0,
+					left: "50%",
+					transform: "translateX(-50%)",
+					width: "65px", // 49 + 16
+					height: "2px",
+					backgroundColor: "secondary.01",
+				},
+			},
+		},
+	},
+});
+
+export const MoreOptions = styled("div", {
+	base: {
+		...flexItem,
+		flex: "1 1 90px",
+	},
+});
+
+export const Gap = styled("div", {
+	base: {
+		width: "8px",
+		height: "100%",
+	},
+});

--- a/src/features/matching/components/MatchingMenu/index.tsx
+++ b/src/features/matching/components/MatchingMenu/index.tsx
@@ -1,0 +1,60 @@
+import Dropdown from "@/features/matching/components/Dropdown";
+import {
+	MatchingMenuContainer,
+	WriteButton,
+} from "@/features/matching/components/MatchingMenu/style";
+import {
+	questOptions,
+	lvOptions,
+	regionOptions,
+} from "@/data/MainOptions/mainOptions";
+
+type MatchingMenuProps = {
+	openModal: () => void;
+	quest: string;
+	setQuest: (value: string) => void;
+	lv: string;
+	setLv: (value: string) => void;
+	region: string;
+	setRegion: (value: string) => void;
+};
+
+export default function MatchingMenu({
+	openModal,
+	quest,
+	setQuest,
+	lv,
+	setLv,
+	region,
+	setRegion,
+}: MatchingMenuProps) {
+	return (
+		<MatchingMenuContainer>
+			<div>
+				<Dropdown
+					placeholder="퀘스트 종류"
+					value={quest}
+					setValue={setQuest}
+					options={questOptions}
+					style="genshin"
+				/>
+				<Dropdown
+					placeholder="월드 레벨"
+					value={lv}
+					setValue={setLv}
+					options={lvOptions}
+					style="genshin"
+				/>
+			</div>
+			<div>
+				<Dropdown
+					value={region}
+					setValue={setRegion}
+					options={regionOptions}
+					style="genshin"
+				/>
+				<WriteButton onClick={openModal}>구인글 쓰기</WriteButton>
+			</div>
+		</MatchingMenuContainer>
+	);
+}

--- a/src/features/matching/components/MatchingMenu/style.ts
+++ b/src/features/matching/components/MatchingMenu/style.ts
@@ -1,0 +1,88 @@
+import { styled } from "@/../styled-system/jsx";
+
+const flexCenter = {
+	display: "flex",
+	alignItems: "center",
+	justifyContent: "center",
+	height: "100%",
+};
+
+const fontStyle = {
+	color: "gray.01",
+	fontSize: "14px",
+	fontWeight: "bold",
+};
+
+const flexItem = {
+	...flexCenter,
+	...fontStyle,
+	position: "relative",
+	cursor: "pointer",
+	flex: "1 1 auto",
+};
+
+export const MatchingMenuContainer = styled("div", {
+	base: {
+		display: "flex",
+		width: "100%",
+		alignItems: "center",
+		justifyContent: "space-between",
+		padding: "0 30px",
+		marginTop: "30px",
+		marginBottom: "30px",
+		flexShrink: 0,
+		"& div": {
+			display: "flex",
+			alignItems: "center",
+			gap: "20px",
+		},
+	},
+});
+
+export const WriteButton = styled("button", {
+	base: {
+		display: "flex",
+		alignItems: "center",
+		justifyContent: "center",
+		width: "113px",
+		height: "40px",
+		backgroundColor: "primary.01",
+		color: "secondary.03",
+		fontSize: "14px",
+		fontWeight: "medium",
+		letterSpacing: "0",
+		borderRadius: "4px",
+		cursor: "pointer",
+		border: "1px solid #696969",
+		backgroundImage: "url('/svgs/write.svg')",
+		backgroundRepeat: "no-repeat",
+		backgroundSize: "24px 24px",
+		backgroundPosition: "10px center",
+		paddingLeft: "35px",
+		boxSizing: "border-box",
+	},
+});
+
+export const UserName = styled("div", {
+	base: {
+		...flexItem,
+		flex: "1 1 200px",
+	},
+	variants: {
+		select: {
+			true: {
+				color: "secondary.01",
+				"&::before": {
+					content: '""',
+					position: "absolute",
+					bottom: 0,
+					left: "50%",
+					transform: "translateX(-50%)",
+					width: "53px", // 37 + 16
+					height: "2px",
+					backgroundColor: "secondary.01",
+				},
+			},
+		},
+	},
+});

--- a/src/features/matching/components/MatchingPostItem/index.tsx
+++ b/src/features/matching/components/MatchingPostItem/index.tsx
@@ -28,6 +28,8 @@ import {
 import Modal from "../Modal";
 import { useRef, useState } from "react";
 import useOutsideClick from "@/hooks/useOutsideClick";
+import { PostContent } from "@/features/matching/components/Tab";
+import dayjs from "dayjs";
 // 퀘스트 종류 이미지
 export const questImage = {
 	domain: "/svgs/quests/domain.svg",
@@ -39,30 +41,50 @@ export const questImage = {
 };
 
 interface MatchingPostItemProps {
-	type: string;
+	type: "report" | "write";
+	item: PostContent;
 	selected?: string;
 	isMobile?: boolean;
+	email: string;
 }
 
 export default function MatchingPostItem({
 	type,
 	selected,
+	item,
 	isMobile = false,
+	email,
 }: MatchingPostItemProps) {
 	const [isModalOpen, setIsModalOpen] = useState(false);
 	const [isMenuOpen, setIsMenuOpen] = useState(false);
-	const menuRef = useRef<HTMLDivElement>(null);
 
+	const menuRef = useRef<HTMLDivElement>(null);
 	const openModal = () => {
 		setIsModalOpen(true);
 		setIsMenuOpen(false);
 	};
 
 	const closeModal = () => setIsModalOpen(false);
-	const openMenu = () => setIsMenuOpen(true);
 	const closeMenu = () => setIsMenuOpen(false);
 
+	const handleMoreOptionsClick = () => {
+		if (type === "write") {
+			setIsMenuOpen(!isMenuOpen);
+		} else {
+			openModal();
+		}
+	};
+
 	useOutsideClick(menuRef, closeMenu);
+
+	const createdAt = new Date(item.createdAt);
+	const now = new Date();
+	const timeDifference = now.getTime() - createdAt.getTime();
+	let minutesAgo = Math.floor(timeDifference / (1000 * 60));
+	let timeAgo = "";
+	if (minutesAgo > 60) {
+		timeAgo = dayjs(createdAt).format("YYYY-MM-DD HH:mm");
+	}
 
 	return (
 		<>
@@ -71,8 +93,8 @@ export default function MatchingPostItem({
 					<UserName selected={selected === "userName"}>
 						<ProfileImage />
 						<UserInfo>
-							<Text>유저명</Text>
-							<UserIdButton>UID 80000000</UserIdButton>
+							<Text>{item.writerName}</Text>
+							<UserIdButton>{item.uid}</UserIdButton>
 						</UserInfo>
 					</UserName>
 					<QuestType selected={selected === "questType"}>
@@ -83,39 +105,29 @@ export default function MatchingPostItem({
 						<Text>비경</Text>
 					</QuestType>
 					<WorldLevel selected={selected === "worldLevel"}>
-						<Text>7</Text>
+						<Text>{item.wordLevel}</Text>
 					</WorldLevel>
 					<Message selected={selected === "message"}>
-						<MessageText>
-							맵 밀어주실 착한 분 구해요.한 5판 할 것 같아요.
-							가나다라마바사아자차카타파하
-						</MessageText>
+						<MessageText>{item.title}</MessageText>
 					</Message>
 					<TimeAgo selected={selected === "timeAgo"}>
-						<Text color="gray02">1분 전</Text>
+						<Text color="gray02">
+							{minutesAgo > 60 ? timeAgo : minutesAgo + "분 전"}
+						</Text>
 					</TimeAgo>
 					<MoreOptions>
 						<MoreOptionsButton
-							type="moreOption"
-							onClick={openMenu}
+							type={type === "write" ? "moreOption" : "report"}
+							onClick={handleMoreOptionsClick}
 							className="moreOption"
 						/>
-						{isMenuOpen && type !== "write" ? (
-							<MenuContainer ref={menuRef}>
+						{isMenuOpen && type === "write" && (
+							<MenuContainer ref={menuRef} isMobile={isMobile}>
 								<MenuItem onClick={closeMenu}>종료</MenuItem>
 								<MenuItem onClick={closeMenu}>삭제</MenuItem>
 								<MenuItem onClick={openModal}>수정</MenuItem>
 								<MenuItem onClick={closeMenu}>끌올</MenuItem>
 							</MenuContainer>
-						) : (
-							""
-						)}
-
-						{isModalOpen && type === "report" && (
-							<Modal onClose={closeModal} type="report" isMobile={isMobile} />
-						)}
-						{isModalOpen && type === "write" && (
-							<Modal onClose={closeModal} type="write" isMobile={isMobile} />
 						)}
 					</MoreOptions>
 				</ItemContainer>
@@ -147,11 +159,11 @@ export default function MatchingPostItem({
 						</InfoWrapper>
 						<MobileMoreOptions>
 							<MoreOptionsButton
-								type="moreOption"
+								type={email === item.writerEmail ? "moreOption" : "report"}
 								isMobile={isMobile}
-								onClick={openMenu}
+								onClick={handleMoreOptionsClick}
 							/>
-							{isMenuOpen && (
+							{isMenuOpen && type === "write" && (
 								<MenuContainer ref={menuRef} isMobile={isMobile}>
 									<MenuItem onClick={closeMenu}>종료</MenuItem>
 									<MenuItem onClick={closeMenu}>삭제</MenuItem>
@@ -161,10 +173,10 @@ export default function MatchingPostItem({
 							)}
 						</MobileMoreOptions>
 					</InfoContainer>
-					{isModalOpen && (
-						<Modal onClose={closeModal} type="write" isMobile={isMobile} />
-					)}
 				</ItemContainer>
+			)}
+			{isModalOpen && (
+				<Modal onClose={closeModal} type={type} isMobile={isMobile} />
 			)}
 		</>
 	);

--- a/src/features/matching/components/MatchingPostItem/styles.ts
+++ b/src/features/matching/components/MatchingPostItem/styles.ts
@@ -209,6 +209,7 @@ export const TimeAgo = styled("div", {
 		flex: "1 1 140px",
 		textStyle: "sm",
 		color: "gray.02",
+		textAlign: "center",
 	},
 	...selectedVariant,
 });

--- a/src/features/matching/components/Modal/index.tsx
+++ b/src/features/matching/components/Modal/index.tsx
@@ -51,9 +51,9 @@ export default function Modal({ onClose, type, isMobile = false }: ModalProps) {
 				</ModalHeader>
 				<ModalContent type={type} isMobile={isMobile}>
 					{type === "write" ? (
-						<ReportModal />
-					) : (
 						<WriteModal onClose={onClose} isMobile={isMobile} />
+					) : (
+						<ReportModal />
 					)}
 				</ModalContent>
 			</ModalContainer>

--- a/src/features/matching/components/PostList/index.tsx
+++ b/src/features/matching/components/PostList/index.tsx
@@ -1,0 +1,38 @@
+import MatchingPostItem from "@/features/matching/components/MatchingPostItem";
+import { PostListContainer, VisibleTabList } from "./style";
+import { nanoid } from "nanoid";
+import { PostContent } from "@/features/matching/components/Tab";
+
+type PostListProps = {
+	postData: PostContent[] | undefined;
+	hasNextPage: boolean;
+	isLoading: boolean;
+	scrollRef: any;
+	selectType: string;
+	email: string;
+};
+
+export default function PostList({
+	postData = [],
+	hasNextPage,
+	isLoading,
+	scrollRef,
+	selectType,
+	email,
+}: PostListProps) {
+	return (
+		<PostListContainer>
+			{postData &&
+				postData.map((item) => (
+					<MatchingPostItem
+						key={nanoid()}
+						selected={selectType}
+						type={item.writerEmail === email ? "write" : "report"}
+						item={item}
+						email={email}
+					/>
+				))}
+			{hasNextPage && !isLoading && <VisibleTabList ref={scrollRef} />}
+		</PostListContainer>
+	);
+}

--- a/src/features/matching/components/PostList/style.ts
+++ b/src/features/matching/components/PostList/style.ts
@@ -1,0 +1,53 @@
+import { styled } from "@/../styled-system/jsx";
+
+export const PostListContainer = styled("div", {
+	base: {
+		width: "100%",
+		height: "100%",
+		marginTop: "1px",
+		display: "flex",
+		flexDirection: "column",
+		position: "relative",
+		overflowY: "auto",
+		mx: "auto",
+		flexGrow: 1,
+		paddingLeft: "5px",
+		"&::-webkit-scrollbar": {
+			width: "8px",
+		},
+		"&::-webkit-scrollbar-thumb": {
+			width: "6px",
+			backgroundColor: "#F4F4F4",
+			borderRadius: "2px",
+			border: "1px solid transparent",
+			backgroundClip: "padding-box",
+			backgroundImage: "url('/svgs/scroll.svg')",
+			backgroundRepeat: "no-repeat",
+			backgroundSize: "4px calc(100% - 2px)",
+			backgroundPosition: "center center",
+		},
+		"&::-webkit-scrollbar-track": {
+			backgroundColor: "gray.01",
+			borderRadius: "2px",
+		},
+	},
+	variants: {
+		isMobile: {
+			true: {
+				paddingLeft: "0px",
+				marginTop: "0",
+				marginBottom: "30px",
+				// maxHeight: 'calc(100% - 95px)',
+			},
+		},
+	},
+});
+
+export const VisibleTabList = styled("div", {
+	base: {
+		width: "100%",
+		height: "1px", // 충분한 높이 설정
+		display: "block",
+		flex: "0 0 1px",
+	},
+});

--- a/src/features/matching/components/Tab/index.tsx
+++ b/src/features/matching/components/Tab/index.tsx
@@ -3,19 +3,7 @@ import {
 	Container,
 	TabContainer,
 	TabItem,
-	MatchingMenu,
-	WriteButton,
-	MatchingHeader,
-	UserName,
-	QuestType,
-	WorldLevel,
-	Message,
-	TimeAgo,
-	MoreOptions,
-	Gap,
-	PostList,
 	MobileContainer,
-	FilterContainer,
 	EventContainer,
 	EventItem,
 	BannerImage,
@@ -24,15 +12,19 @@ import {
 	EventDate,
 	EventShortCut,
 	MobileWriteButton,
-	VisibleTabList,
 } from "./styles";
 import MatchingPostItem from "../MatchingPostItem";
-import Dropdown from "../Dropdown";
+
 import Modal from "../Modal";
 import { useState, useEffect } from "react";
 import { useRef } from "react";
 import { useMainPostObserve } from "@/hooks/useMainPostObserve";
-import { InfiniteData } from "@tanstack/react-query";
+import { nanoid } from "nanoid/non-secure";
+import userStore from "@/stores/userStore";
+import MatchingMenu from "@/features/matching/components/MatchingMenu";
+import MobileFilterContainer from "@/features/matching/mobile/components/MobileContainer";
+import MatchingHeader from "@/features/matching/components/MatchingHeader";
+import PostList from "@/features/matching/components/PostList";
 
 interface TabProps {
 	isMobile?: boolean;
@@ -42,8 +34,10 @@ interface MatchingProps {
 	isMobile?: boolean;
 }
 
-interface PostData {
+export interface PostContent {
 	title: string;
+	writerName: string;
+	writerEmail: string;
 	id: number;
 	uid: number;
 	region: string;
@@ -56,6 +50,14 @@ interface PostData {
 	sortedAt: string;
 	createdAt: string;
 	updatedAt: string;
+}
+
+interface PostData {
+	content: PostContent[];
+	page: number;
+	size: number;
+	totalElements: number;
+	totalPages: number;
 }
 
 export default function Tab({ isMobile = false }: TabProps) {
@@ -107,18 +109,21 @@ export default function Tab({ isMobile = false }: TabProps) {
 
 function Matching({ isMobile = false }: MatchingProps) {
 	const [isModalOpen, setIsModalOpen] = useState(false);
+	const [selectType, setSelectType] = useState("");
+	const [postData, setPostData] = useState<PostContent[]>();
 	const [quest, setQuest] = useState("");
 	const [lv, setLv] = useState("");
 	const [region, setRegion] = useState("ASIA");
-	const [selectType, setSelectType] = useState("");
-	const [postData, setPostData] = useState<PostData[]>([]);
 	const scrollRef = useRef<HTMLDivElement>(null);
+	const { email } = userStore();
 	const { data, isLoading, hasNextPage } = useMainPostObserve(scrollRef);
 	useEffect(() => {
-		if (data?.pages) {
-			const newPosts = data.pages.flatMap((page) => page);
-			setPostData((prev) => [...prev, ...newPosts]);
+		const pageData = data?.pages[0] as unknown as PostData;
+		if (pageData?.content) {
+			const newPosts = pageData.content;
+			setPostData((prev) => (prev ? [...prev, ...newPosts] : newPosts));
 		}
+		console.log(isLoading);
 	}, [data]);
 
 	const openModal = () => setIsModalOpen(true);
@@ -127,149 +132,52 @@ function Matching({ isMobile = false }: MatchingProps) {
 		setSelectType((prevType) => (prevType === type ? "" : type));
 	};
 
-	const questOptions = [
-		{ value: "일반비경" },
-		{ value: "이벤트 퀘스트" },
-		{ value: "영역 토벌" },
-		{ value: "일일 임무" },
-		{ value: "맵 탐사" },
-		{ value: "채집" },
-	];
-
-	const lvOptions = [
-		{ value: "1" },
-		{ value: "2" },
-		{ value: "3" },
-		{ value: "4" },
-		{ value: "5" },
-		{ value: "6" },
-		{ value: "7" },
-		{ value: "8" },
-		{ value: "9" },
-	];
-
-	const regionOptions = [
-		{ value: "ASIA" },
-		{ value: "AMERICA" },
-		{ value: "EUROPE" },
-		{ value: "CHINA" },
-		{ value: "TW, HK, MO" },
-	];
-
 	return (
 		<>
 			{!isMobile ? (
 				<>
-					<MatchingMenu>
-						<div>
-							<Dropdown
-								placeholder="퀘스트 종류"
-								value={quest}
-								setValue={setQuest}
-								options={questOptions}
-								style="genshin"
-							/>
-							<Dropdown
-								placeholder="월드 레벨"
-								value={lv}
-								setValue={setLv}
-								options={lvOptions}
-								style="genshin"
-							/>
-						</div>
-						<div>
-							<Dropdown
-								value={region}
-								setValue={setRegion}
-								options={regionOptions}
-								style="genshin"
-							/>
-							<WriteButton onClick={openModal}>구인글 쓰기</WriteButton>
-						</div>
-					</MatchingMenu>
-					<MatchingHeader>
-						<UserName
-							select={selectType === "userName"}
-							onClick={() => handleSelectType("userName")}
-						>
-							유저명
-						</UserName>
-						<QuestType
-							select={selectType === "questType"}
-							onClick={() => handleSelectType("questType")}
-						>
-							퀘스트 종류
-						</QuestType>
-						<WorldLevel
-							select={selectType === "worldLevel"}
-							onClick={() => handleSelectType("worldLevel")}
-						>
-							월드 레벨
-						</WorldLevel>
-						<Message
-							select={selectType === "message"}
-							onClick={() => handleSelectType("message")}
-						>
-							이야기
-						</Message>
-						<TimeAgo
-							select={selectType === "timeAgo"}
-							onClick={() => handleSelectType("timeAgo")}
-						>
-							등록일시
-						</TimeAgo>
-						<MoreOptions></MoreOptions>
-						<Gap />
-					</MatchingHeader>
-					<PostList>
-						{postData.map((_, index) => (
-							<MatchingPostItem
-								key={index}
-								selected={selectType}
-								type={"report"}
-							/>
-						))}
-						{hasNextPage && !isLoading && <VisibleTabList ref={scrollRef} />}
-					</PostList>
+					<MatchingMenu
+						openModal={openModal}
+						quest={quest}
+						setQuest={setQuest}
+						lv={lv}
+						setLv={setLv}
+						region={region}
+						setRegion={setRegion}
+					/>
+					<MatchingHeader
+						selectType={selectType}
+						handleSelectType={handleSelectType}
+					/>
+					<PostList
+						postData={postData}
+						hasNextPage={hasNextPage}
+						isLoading={isLoading}
+						scrollRef={scrollRef}
+						selectType={selectType}
+						email={email}
+					/>
 					{isModalOpen && <Modal onClose={closeModal} type="write" />}
 				</>
 			) : (
 				<MobileContainer>
-					<FilterContainer>
-						<Dropdown
-							placeholder="퀘스트 종류"
-							value={quest}
-							setValue={setQuest}
-							options={questOptions}
-							style="genshin"
-							isMobile={isMobile}
-						/>
-						<Dropdown
-							placeholder="월드 레벨"
-							value={lv}
-							setValue={setLv}
-							options={lvOptions}
-							style="genshin"
-							isMobile={isMobile}
-						/>
-						<Dropdown
-							value={region}
-							setValue={setRegion}
-							options={regionOptions}
-							style="genshin"
-							isMobile={isMobile}
-						/>
-					</FilterContainer>
-					<PostList isMobile={isMobile}>
-						{Array.from({ length: 50 }).map((_, index) => (
-							<MatchingPostItem
-								key={index}
-								selected={selectType}
-								isMobile={isMobile}
-								type={"write"}
-							/>
-						))}
-					</PostList>
+					<MobileFilterContainer
+						isMobile={isMobile}
+						quest={quest}
+						setQuest={setQuest}
+						lv={lv}
+						setLv={setLv}
+						region={region}
+						setRegion={setRegion}
+					/>
+					<PostList
+						postData={postData}
+						hasNextPage={hasNextPage}
+						isLoading={isLoading}
+						scrollRef={scrollRef}
+						selectType={selectType}
+						email={email}
+					/>
 					<MobileWriteButton onClick={openModal} />
 					{isModalOpen && (
 						<Modal onClose={closeModal} type="write" isMobile={isMobile} />

--- a/src/features/matching/components/Tab/styles.ts
+++ b/src/features/matching/components/Tab/styles.ts
@@ -164,31 +164,7 @@ export const MatchingMenu = styled("div", {
 	},
 });
 
-export const WriteButton = styled("button", {
-	base: {
-		display: "flex",
-		alignItems: "center",
-		justifyContent: "center",
-		width: "113px",
-		height: "40px",
-		backgroundColor: "primary.01",
-		color: "secondary.03",
-		fontSize: "14px",
-		fontWeight: "medium",
-		letterSpacing: "0",
-		borderRadius: "4px",
-		cursor: "pointer",
-		border: "1px solid #696969",
-		backgroundImage: "url('/svgs/write.svg')",
-		backgroundRepeat: "no-repeat",
-		backgroundSize: "24px 24px",
-		backgroundPosition: "10px center",
-		paddingLeft: "35px",
-		boxSizing: "border-box",
-	},
-});
-
-export const MatchingHeader = styled("div", {
+export const MatchingHeaderContainer = styled("div", {
 	base: {
 		display: "flex",
 		alignItems: "center",
@@ -316,20 +292,6 @@ export const TimeAgo = styled("div", {
 				},
 			},
 		},
-	},
-});
-
-export const MoreOptions = styled("div", {
-	base: {
-		...flexItem,
-		flex: "1 1 90px",
-	},
-});
-
-export const Gap = styled("div", {
-	base: {
-		width: "8px",
-		height: "100%",
 	},
 });
 
@@ -507,13 +469,5 @@ export const MobileWriteButton = styled("button", {
 		bottom: "20px",
 		right: "20px",
 		zIndex: 2,
-	},
-});
-
-export const VisibleTabList = styled("div", {
-	base: {
-		width: "100%",
-		height: "1px", // 충분한 높이 설정
-		display: "block",
 	},
 });

--- a/src/features/matching/mobile/components/MobileContainer/index.tsx
+++ b/src/features/matching/mobile/components/MobileContainer/index.tsx
@@ -1,0 +1,55 @@
+import Dropdown from "@/features/matching/components/Dropdown";
+import { FilterContainer } from "./style";
+import {
+	questOptions,
+	lvOptions,
+	regionOptions,
+} from "@/data/MainOptions/mainOptions";
+
+type MobileFilterContainerProps = {
+	isMobile: boolean;
+	quest: string;
+	setQuest: (value: string) => void;
+	lv: string;
+	setLv: (value: string) => void;
+	region: string;
+	setRegion: (value: string) => void;
+};
+
+export default function MobileFilterContainer({
+	isMobile,
+	quest,
+	setQuest,
+	lv,
+	setLv,
+	region,
+	setRegion,
+}: MobileFilterContainerProps) {
+	return (
+		<FilterContainer>
+			<Dropdown
+				placeholder="퀘스트 종류"
+				value={quest}
+				setValue={setQuest}
+				options={questOptions}
+				style="genshin"
+				isMobile={isMobile}
+			/>
+			<Dropdown
+				placeholder="월드 레벨"
+				value={lv}
+				setValue={setLv}
+				options={lvOptions}
+				style="genshin"
+				isMobile={isMobile}
+			/>
+			<Dropdown
+				value={region}
+				setValue={setRegion}
+				options={regionOptions}
+				style="genshin"
+				isMobile={isMobile}
+			/>
+		</FilterContainer>
+	);
+}

--- a/src/features/matching/mobile/components/MobileContainer/style.ts
+++ b/src/features/matching/mobile/components/MobileContainer/style.ts
@@ -1,0 +1,15 @@
+import { styled } from "@/../styled-system/jsx";
+
+export const FilterContainer = styled("div", {
+	base: {
+		display: "flex",
+		width: "100%",
+		height: "40px",
+		gap: "20px",
+		justifyContent: "space-between",
+		"& > *": {
+			flex: "1 1 auto",
+			maxWidth: "100%",
+		},
+	},
+});

--- a/src/hooks/useMainPostObserve.ts
+++ b/src/hooks/useMainPostObserve.ts
@@ -8,7 +8,7 @@ import { RefObject, useEffect } from "react";
 
 const observerOption = {
 	root: null,
-	rootMargin: "0px",
+	rootMargin: "100px",
 	threshold: 0,
 };
 
@@ -18,14 +18,10 @@ export function useMainPostObserve(scrollRef: RefObject<HTMLDivElement>) {
 		queryFn: ({ pageParam = 1 }) =>
 			getMainPostList({ page: pageParam, size: 20 }),
 		initialPageParam: 1,
-		retry: 2,
 		getNextPageParam: (lastPage) => {
-			// 더 이상 데이터가 없으면 undefined 반환
-			if (!lastPage.hasMore) return undefined;
-			// 다음 페이지 번호 반환
-			return lastPage.currentPage + 1;
+			if (!lastPage || lastPage.page >= lastPage.totalPages) return undefined;
+			return lastPage.page + 1;
 		},
-		// refetchOnWindowFocus: false,
 		staleTime: 1000 * 60 * 5,
 	});
 
@@ -38,6 +34,7 @@ export function useMainPostObserve(scrollRef: RefObject<HTMLDivElement>) {
 			}
 		}, observerOption);
 
+		console.log(scrollRef.current);
 		observer.observe(scrollRef.current);
 
 		return () => {

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -25,7 +25,7 @@ type setUserActionType = {
 };
 
 const defaultUserInfo = {
-	email: "gmail",
+	email: "nextconnect.lab@gmail.com",
 	userProfile: {
 		passwordLeng: "10",
 		uid: "85171071",


### PR DESCRIPTION
메인페이지의 구인글 리스트 api 연동 및 코드 추상화를 진행 했습니다. 기존에 정한 대로 무한 스크롤을 이용하여 구현하였고 그 과정에서 useMainPostObserve.ts라는 새로운 훅을 제작하여 사용 하였습니다. 기존에 이미 만들어진 useObserver.ts를 사용하지 않은 이유는 useInfiniteQuery를 해당 로직과 함께 사용하자니 코드가 분석하기가 어려워지고 길어져 중복되는 코드가 있을 수 있지만 따로 분리하기로 하였습니다.

기존 Tab 컴포넌트의 index.tsx파일 안의 내용을 추상화 하였습니다.

<details>
 <summary>
추상화한 코드
</summary>

![image](https://github.com/user-attachments/assets/abe1c4e7-ce1d-49c5-8ce8-8a1d01b0fd23)
</details>

<details>

 <summary>
   추상화 이전 코드
</summary>

![스크린샷 2024-12-24 043944](https://github.com/user-attachments/assets/29183dbc-1f11-40fc-8ae3-b6d5d9d6b1c1)

![스크린샷 2024-12-24 043952](https://github.com/user-attachments/assets/0f551bbf-ef87-46f1-ba21-59583371a3ec)

![스크린샷 2024-12-24 044001](https://github.com/user-attachments/assets/b9efde25-2194-4fb2-b84a-9e7329130b19)

</details>


> 연동 모습

![ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/48c5b5c1-2c22-456e-b70f-6264969f3233)
