### PR TITLE
Oauth Session 초기화 값 수정

### DIFF
--- a/src/features/matching/components/Tab/index.tsx
+++ b/src/features/matching/components/Tab/index.tsx
@@ -100,8 +100,6 @@ export default function Tab({ isMobile = false }: TabProps) {
 	const OauthSignUpModalClose = async () => {
 		await update({
 			user: {
-				email: "",
-				provider: "",
 				status: 0,
 				responseOk: false,
 			},
@@ -130,11 +128,11 @@ export default function Tab({ isMobile = false }: TabProps) {
 		};
 
 		// 세션 정보가 없는 경우 UID 입력 모달창 닫기
-		if (!session?.user.email || !session?.user.provider) {
+		if (session?.user.status === 0) {
 			setOauthUidModalState(false);
 		}
 		// 이미 회원인경우 로그인 로직 실행하여 쿠키 등록
-
+		console.log(session?.user);
 		if (session?.user.status === 200) {
 			loadingToast(
 				oauthSignIn(session.user.email, () => setOauthUidModalState(true)),


### PR DESCRIPTION
Oauth 회원가입시 초기화 되는 session의 값을 변경하였습니다. 

기존: email , provider , status, responseOk  초기화

변경: status,responseOk 초기화 , email, provider 유지 

email , provider = 다른 필요한 API에 이용하기 위해 유지