### PR TITLE
메인 페이지 접속시 store에 자신의 유저 정보가 없다면 불러오는 로직 추가

### DIFF
--- a/src/app/api/getAccessToken/route.ts
+++ b/src/app/api/getAccessToken/route.ts
@@ -1,11 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 
-export async function POST(req: NextRequest) {
+export async function GET(req: NextRequest) {
 	try {
-		const accessToken = req.cookies.get("accessToken")?.value;
-		if (!accessToken) throw new Error("accessToken이 없습니다.");
+		const accessToken = req.cookies.get("AccessToken")?.value;
+		if (!accessToken) throw new Error("AccessToken이 없습니다.");
 		return NextResponse.json({ message: "성공", accessToken }, { status: 200 });
 	} catch (error) {
-		return NextResponse.json({ message: "실패" }, { status: 400 });
+		const err = error as Error;
+		return NextResponse.json({ message: err.message }, { status: 400 });
 	}
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,37 +27,35 @@ export default function Home() {
 
 	// 컴포넌트가 마운트 되기 전에는 렌더링 하지 않음
 	useEffect(() => {
-		try {
-			setMounted(true);
-			const responseData = async () => {
-				const tokenResponse = await getAccessToken(setIsLogin);
-				const tokenResult = await tokenResponse.json();
-				const accessToken = tokenResult.accessToken;
-				if (!tokenResponse.ok) {
-					switch (
-						tokenResponse.status
-						// 에러 핸들러
-					) {
-					}
+		setMounted(true);
+		const responseData = async () => {
+			const tokenResponse = await getAccessToken(setIsLogin);
+			const tokenResult = await tokenResponse.json();
+			const accessToken = tokenResult.accessToken;
+			if (!tokenResponse.ok) {
+				switch (tokenResponse.status) {
+					// 에러 핸들러
+					default:
+						return;
 				}
-				const userProfileDataResponse = await getUserInfo(accessToken);
-				if (!userProfileDataResponse.ok) {
-					switch (tokenResponse.status) {
-						// 에러 핸들러
-						case 404:
-							errorToast("유저 정보를 찾을 수 없습니다.");
-							break;
-					}
-				}
-				const result = await userProfileDataResponse.json();
-				setUserInfo({ ...result });
-			};
-			// 정보가 갱신되지 않았을때만 fetch 실행행
-			if (uid === 0) {
-				responseData();
 			}
-		} catch (error) {
-			router.push("/error");
+			const userProfileDataResponse = await getUserInfo(accessToken);
+			if (!userProfileDataResponse.ok) {
+				switch (tokenResponse.status) {
+					// 에러 핸들러
+					case 404:
+						errorToast("유저 정보를 찾을 수 없습니다.");
+						break;
+					default:
+						return;
+				}
+			}
+			const result = await userProfileDataResponse.json();
+			setUserInfo({ ...result });
+		};
+		// 정보가 갱신되지 않았을때만 fetch 실행행
+		if (uid === 0) {
+			responseData();
 		}
 	}, []);
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,11 @@ import Sidebar from "@/features/matching/components/sidebar";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 import { getAccessToken } from "@/fetch/Token/getAccessToken/getAccessToken";
+import useLoginStateStore from "@/stores/loginStateStore";
+import { errorToast } from "@/utils/customToast/customToast";
+import { useRouter } from "next/navigation";
+import userStore from "@/stores/userStore";
+import { getUserInfo } from "@/fetch/User/getUserInfo/getUserInfo";
 
 export default function Home() {
 	const [mounted, setMounted] = useState(false);
@@ -15,11 +20,45 @@ export default function Home() {
 	const isMobile = useMediaQuery({
 		query: `(max-width:${mobileWidth}px)`,
 	});
+	const { setIsLogin } = useLoginStateStore();
+	const { setUserInfo, uid } = userStore();
+
+	const router = useRouter();
 
 	// 컴포넌트가 마운트 되기 전에는 렌더링 하지 않음
 	useEffect(() => {
-		setMounted(true);
-		getAccessToken();
+		try {
+			setMounted(true);
+			const responseData = async () => {
+				const tokenResponse = await getAccessToken(setIsLogin);
+				const tokenResult = await tokenResponse.json();
+				const accessToken = tokenResult.accessToken;
+				if (!tokenResponse.ok) {
+					switch (
+						tokenResponse.status
+						// 에러 핸들러
+					) {
+					}
+				}
+				const userProfileDataResponse = await getUserInfo(accessToken);
+				if (!userProfileDataResponse.ok) {
+					switch (tokenResponse.status) {
+						// 에러 핸들러
+						case 404:
+							errorToast("유저 정보를 찾을 수 없습니다.");
+							break;
+					}
+				}
+				const result = await userProfileDataResponse.json();
+				setUserInfo({ ...result });
+			};
+			// 정보가 갱신되지 않았을때만 fetch 실행행
+			if (uid === 0) {
+				responseData();
+			}
+		} catch (error) {
+			router.push("/error");
+		}
 	}, []);
 
 	if (!mounted) {

--- a/src/features/matching/components/Modal/index.tsx
+++ b/src/features/matching/components/Modal/index.tsx
@@ -18,6 +18,7 @@ import AddPostModalMobile from "@/features/matching/mobile/components/modalMobil
 import { addPostSignIn } from "@/fetch/Main/addPostList/addPostList";
 import { loadingToast } from "@/utils/customToast/customToast";
 import { loadingToastType } from "@/utils/customToast/customToast";
+import useLoginStateStore from "@/stores/loginStateStore";
 
 interface ModalProps {
 	onClose: () => void;
@@ -91,6 +92,7 @@ function WriteModal({
 }) {
 	const [quest, setQuest] = useState("");
 	const [time, setTime] = useState("1시간");
+	const { isLogin } = useLoginStateStore();
 	const {
 		register,
 		handleSubmit,
@@ -104,7 +106,7 @@ function WriteModal({
 					action="#"
 					method="post"
 					onSubmit={handleSubmit((data) =>
-						postHandler(data, quest, time, loadingToast, onClose),
+						postHandler(data, quest, time, loadingToast, onClose, isLogin),
 					)}
 				>
 					<AddPostModalPC
@@ -123,7 +125,7 @@ function WriteModal({
 					action="#"
 					method="post"
 					onSubmit={handleSubmit((data) =>
-						postHandler(data, quest, time, loadingToast, onClose),
+						postHandler(data, quest, time, loadingToast, onClose, isLogin),
 					)}
 				>
 					<AddPostModalMobile
@@ -159,20 +161,23 @@ async function postHandler(
 	time: string,
 	loadingToast: loadingToastType,
 	onClose: () => void,
+	isLogin: boolean,
 ) {
 	await loadingToast(
-		addPostSignIn(data, quest, time),
+		addPostSignIn(data, quest, time, isLogin),
 		"등록 중입니다",
 		"등록 완료!",
 		"등록에 실패했습니다.",
 	)
 		.then((response) => {
+			console.log(response);
 			if (response.ok) {
 				onClose();
 			}
 		})
 		.catch((error) => {
 			const responseCode = error.status;
+			console.log(error.response);
 			// 코드에 따른 예외처리리
 		});
 }

--- a/src/fetch/Main/addPostList/addPostList.ts
+++ b/src/fetch/Main/addPostList/addPostList.ts
@@ -1,4 +1,6 @@
 import { FieldValues } from "react-hook-form";
+import { getAccessToken } from "@/fetch/Token/getAccessToken/getAccessToken";
+import useLoginStateStore from "@/stores/loginStateStore";
 
 class returnResponse extends Error {
 	response: Response;
@@ -12,35 +14,73 @@ export async function addPostSignIn(
 	data: FieldValues,
 	quest: string,
 	time: string,
+	loginState: boolean,
 ) {
 	try {
 		const baseApi = process.env.NEXT_PUBLIC_BaseApi;
 		const signInPostApi = process.env.NEXT_PUBLIC_posting_user;
+		const withOutSignIn = process.env.NEXT_PUBLIC_posting_guest;
 		let autoCompleteTime: number | unknown = "";
+		const defaultQuestCategory = "NORMAL_DOMAIN";
+		const { setIsLogin } = useLoginStateStore();
 		if (!baseApi || !signInPostApi) {
 			throw new Error("api 주소가 없습니다.");
 		}
 		autoCompleteTime = Number(await changeTime(time));
 
 		const changeData = {
-			...data,
-			uid: Number(data.uid),
-			worldLevel: Number(data.worldLevel),
-			questCategory: quest,
 			autoCompleteTime,
+			content: data.content,
+			name: data.name,
+			questCategory: quest || defaultQuestCategory,
+			worldLevel: Number(data.worldLevel),
 		};
 
-		const response = await fetch(`${baseApi}${signInPostApi}`, {
-			method: "POST",
-			body: JSON.stringify({
-				...changeData,
-			}),
-		});
-		if (!response.ok) {
-			switch (response.status) {
-				// 코드에 따른 추가 예외처리
-				default:
-					throw new returnResponse(response);
+		// 로그인후 포스트 등록시 fetch
+		if (loginState) {
+			// 토큰을 가져온 뒤 포스트작성 api 실행
+			const tokenResponse = await getAccessToken(setIsLogin);
+			if (!tokenResponse.ok) {
+				throw new returnResponse(tokenResponse);
+			}
+			const result = await tokenResponse.json();
+			const response = await fetch(`${baseApi}${signInPostApi}`, {
+				method: "POST",
+				headers: {
+					Authorization: `${result.accessToken}`,
+					"Content-Type": "application/json",
+				},
+				body: JSON.stringify({
+					...changeData,
+				}),
+			});
+			if (!response.ok) {
+				switch (response.status) {
+					// 코드에 따른 추가 예외처리
+					default:
+						throw new returnResponse(response);
+				}
+			}
+		}
+		// 로그아웃 상태에서 포스트 등록시 fetch
+		else {
+			if (!withOutSignIn) {
+				throw new Error("api 주소가 없습니다.");
+			}
+			const response = await fetch(`${baseApi}${withOutSignIn}`, {
+				method: "POST",
+				body: JSON.stringify({
+					...changeData,
+					uid: Number(data.uid),
+					password: data.password,
+				}),
+			});
+			if (!response.ok) {
+				switch (response.status) {
+					// 코드에 따른 추가 예외처리
+					default:
+						throw new returnResponse(response);
+				}
 			}
 		}
 	} catch (error) {

--- a/src/fetch/Token/getAccessToken/getAccessToken.ts
+++ b/src/fetch/Token/getAccessToken/getAccessToken.ts
@@ -1,5 +1,3 @@
-import useLoginStateStore from "@/stores/loginStateStore";
-
 class getAccessTokenError extends Error {
 	response: Response;
 	constructor(response: Response) {
@@ -8,31 +6,36 @@ class getAccessTokenError extends Error {
 	}
 }
 
-export async function getAccessToken() {
+export async function getAccessToken(
+	setIsLogin?: (value: boolean) => void,
+): Promise<Response> {
 	try {
-		const baseApi = process.env.NEXT_PUBLIC_BaseApi;
+		const localBaseApi = process.env.NEXT_PUBLIC_LocalBaseApi;
 		const tokenReissue = process.env.NEXT_PUBLIC_getAccessTokenApi;
-		const { setIsLogin } = useLoginStateStore();
-		if (!baseApi || !tokenReissue) {
+		if (!localBaseApi || !tokenReissue) {
 			throw new Error("토큰 재발급에 필요한 환경변수를 찾을 수 없습니다.");
 		}
-		const response = await fetch(`${baseApi}${tokenReissue}`, {
-			method: "POST",
+		const response = await fetch(`${localBaseApi}${tokenReissue}`, {
+			method: "GET",
 			headers: {
 				"Content-Type": "application/json",
 			},
 		});
 		if (!response.ok) {
-			setIsLogin(false);
+			if (setIsLogin) {
+				setIsLogin(false);
+			}
 			throw new getAccessTokenError(response);
 		}
-		const data = await response.json();
-		setIsLogin(true);
-		return data;
+		if (setIsLogin) {
+			setIsLogin(true);
+		}
+		return response;
 	} catch (error) {
+		const err = error as Error;
 		if (error instanceof getAccessTokenError) {
 			return error.response;
 		}
-		return error;
+		return new Response(err.message, { status: 500 });
 	}
 }

--- a/src/fetch/User/getUserInfo/getUserInfo.ts
+++ b/src/fetch/User/getUserInfo/getUserInfo.ts
@@ -1,22 +1,33 @@
-export async function getUserInfo() {
+class returnResponse extends Error {
+	response: Response;
+	constructor(response: Response) {
+		super();
+		this.response = response;
+	}
+}
+
+export async function getUserInfo(accessToken: string): Promise<Response> {
 	try {
 		const baseApi = process.env.NEXT_PUBLIC_BaseApi;
-		const getMyInfoApi = process.env.myInfo;
+		const getMyInfoApi = process.env.NEXT_PUBLIC_myInfoApi;
 		if (!baseApi || !getMyInfoApi) {
 			throw new Error("정보를 조회하는데 필요한 환경변수를 찾지 못했습니다.");
 		}
 		const response = await fetch(`${baseApi}${getMyInfoApi}`, {
-			method: "get",
+			headers: {
+				Authorization: `Bearer ${accessToken}`,
+				"Content-Type": "application/json",
+			},
 		});
 		if (response.status !== 200) {
-			throw new Error("내 정보를 조회하는데 실패했습니다.");
+			throw new returnResponse(response);
 		}
-		const data = await response.json();
-		return data;
+		return response;
 	} catch (error) {
-		if (error instanceof Error) {
-			console.error(error);
+		const err = error as Error;
+		if (error instanceof returnResponse) {
+			return error.response;
 		}
-		return "";
+		return new Response(err.message, { status: 500 });
 	}
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -68,8 +68,9 @@ async function adminPageController(
 		const accessToken = cookies().get("AccessToken") as tokenType;
 		// 	리프레시 토큰으로 얻어온 엑세스 토큰 혹은 기존의 엑세스 토큰을 이용하여 유저 정보를 조회해 등급을 확인
 		if (accessToken) {
-			const userInfo = await getUserInfo();
-			if (userInfo.role !== "관리자") {
+			const userInfo = await getUserInfo(accessToken.value);
+			const result = await userInfo.json();
+			if (result.role !== "ADMIN") {
 				// 관리자가 아닐시 redirect
 				return NextResponse.redirect(new URL("/", req.url));
 			}

--- a/src/utils/customToast/customToast.tsx
+++ b/src/utils/customToast/customToast.tsx
@@ -37,7 +37,7 @@ export function loadingToast(
 		promise
 			.then((response) => {
 				if (!response.ok) {
-					throw new customError(response);
+					throw Promise.reject(new customError(response));
 				}
 				return response;
 			})


### PR DESCRIPTION
메인 페이지의 접속시 store에 자신의 유저 정보가 없다면 getAccessToken 함수를 호출하고 유저 정보를 불러와 store에 저장하는 로직을 추가했습니다. 만약 이미 존재한다면 실행되지 않습니다.

> 루트 page.tsx useEffect문 내부 코드
![image](https://github.com/user-attachments/assets/2b23da65-b5da-4ad6-9672-e05ffb8c4f27)
