### PR TITLE
production baseApi 주소 변경, 강제 페이지 전환 제거

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,7 +1,7 @@
 
 
 # 서버 URL Base Path 
-NEXT_PUBLIC_BaseApi=http://ec2-3-36-98-11.ap-northeast-2.compute.amazonaws.com:8080
+NEXT_PUBLIC_BaseApi=http://ec2-3-36-98-11.ap-northeast-2.compute.amazonaws.com
 
 # 로컬 URL Base Path
 NEXT_PUBLIC_LocalBaseApi=http://localhost:3000

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,6 @@ import Footer from "@/components/Footer";
 import { getAccessToken } from "@/fetch/Token/getAccessToken/getAccessToken";
 import useLoginStateStore from "@/stores/loginStateStore";
 import { errorToast } from "@/utils/customToast/customToast";
-import { useRouter } from "next/navigation";
 import userStore from "@/stores/userStore";
 import { getUserInfo } from "@/fetch/User/getUserInfo/getUserInfo";
 
@@ -22,8 +21,6 @@ export default function Home() {
 	});
 	const { setIsLogin } = useLoginStateStore();
 	const { setUserInfo, uid } = userStore();
-
-	const router = useRouter();
 
 	// 컴포넌트가 마운트 되기 전에는 렌더링 하지 않음
 	useEffect(() => {


### PR DESCRIPTION
1. production의 baseApi를 임시로 변경( 의도치 않은 api 호출발생 방지 ), 
2. 기존의 유저 데이터를 가져오던중 에러가 생길시 강제로 error 페이지로 리다이렉트 되던 로직을 제거 