### PR TITLE
메인페이지 퀘스트 종류 ui문제 해결

### DIFF
--- a/src/features/matching/components/MatchingPostItem/index.tsx
+++ b/src/features/matching/components/MatchingPostItem/index.tsx
@@ -106,7 +106,7 @@ export default function MatchingPostItem({
 							<QuestIcon />
 							<CenteredImage src={questImage} alt="Quest Type" />
 						</QuestIconWrapper>
-						<Text>{quest}</Text>
+						<Text questVariants={true}>{quest}</Text>
 					</QuestType>
 					<WorldLevel selected={selected === "worldLevel"}>
 						<Text>{item.wordLevel}</Text>

--- a/src/features/matching/components/MatchingPostItem/styles.ts
+++ b/src/features/matching/components/MatchingPostItem/styles.ts
@@ -28,6 +28,11 @@ export const Text = styled("p", {
 			gray02: { color: "gray.02" },
 			gray03: { color: "gray.03" },
 		},
+		questVariants: {
+			true: {
+				minWidth: "60px",
+			},
+		},
 	},
 	defaultVariants: {
 		size: "sm",


### PR DESCRIPTION
메인페이지 퀘스트 종류 ui가 이상하게 보이는 문제를 수정했습니다

> 기존 

![스크린샷 2025-01-18 152409](https://github.com/user-attachments/assets/aeccc8e3-c128-4794-bef2-7a25f597306b)

> 수정 후

![스크린샷 2025-01-18 153755](https://github.com/user-attachments/assets/2dc8f060-5b70-40cd-a9d2-c60a6e5e9db0)
